### PR TITLE
close drawer after a header option is clicked

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ yarn docker:build
 yarn docker:up
 ```
 
+The app will be available at `http://localhost` (port 80).
+
 3. Run the data migration (first time only):
 ```bash
 yarn docker:migrate
 ```
 
-The app will be available at `http://localhost` (port 80).
+To use hot-reloading of the frontend run the following command which will run the app at `http://localhost:3000`:
+```
+yarn start:client
+```
 
 > **Note**: Local environment variables are already configured in the `.env` file with sensible defaults for Docker development.
 

--- a/client/src/components/header/components/header-options/headerOptions.tsx
+++ b/client/src/components/header/components/header-options/headerOptions.tsx
@@ -6,8 +6,9 @@ import config from '@config/index';
 import { routes } from '@router';
 
 import { headerOptionsStyles } from './headerOptions.styles';
+import { IHeaderOptionsProps } from './headerOptions.types';
 
-const HeaderOptions = () => {
+const HeaderOptions = ({ onClick }: IHeaderOptionsProps): JSX.Element => {
   const { t } = useTranslation();
   const location = useLocation();
 
@@ -16,22 +17,25 @@ const HeaderOptions = () => {
       <Link
         className={`${routes.about.path === location.pathname ? 'active' : ''} page-link`}
         to={routes.about.path}
+        onClick={onClick}
       >
         {t('about.header')}
       </Link>
       <Link
         className={`${routes.projects.path === location.pathname ? 'active' : ''} page-link`}
         to={routes.projects.path}
+        onClick={onClick}
       >
         {t('projects')}
       </Link>
       <Link
         className={`${routes.education.path === location.pathname ? 'active' : ''} page-link`}
         to={routes.education.path}
+        onClick={onClick}
       >
         {t('education.header')}
       </Link>
-      <a className="page-link" href={config.urls.cv} download>
+      <a className="page-link" href={config.urls.cv} download target="_blank" rel="noreferrer">
         {t('cv')}
       </a>
     </div>

--- a/client/src/components/header/components/header-options/headerOptions.types.ts
+++ b/client/src/components/header/components/header-options/headerOptions.types.ts
@@ -1,0 +1,3 @@
+export interface IHeaderOptionsProps {
+  onClick?: () => void;
+}

--- a/client/src/components/header/header.tsx
+++ b/client/src/components/header/header.tsx
@@ -69,7 +69,7 @@ const Header = () => {
         onClose={closeDrawer}
         extra={<Logo closeDrawer={closeDrawer} />}
       >
-        <HeaderOptions />
+        <HeaderOptions onClick={closeDrawer} />
       </Drawer>
     </>
   );


### PR DESCRIPTION
- Fix drawer behavior by closing it after a header option is clicked. This bug happened after changing Ant Design Link to react-router-dom Link.
- Add more details to README
- Open resume in the new tab